### PR TITLE
Fix add-to-list to org-babel-default-header-args:R

### DIFF
--- a/docs/header-args.md
+++ b/docs/header-args.md
@@ -112,8 +112,10 @@ These default language-specific header arguments can be changed by the user:
     (add-to-list 'org-babel-default-header-args:R
                  '(:session . "*org-R*"))
     
-    (add-to-list 'org-babel-default-header-args:R
-                 '((:width . 640) (:height . 640)))
+    (setf (alist-get :width org-babel-default-header-args:R) 640)
+    (setf (alist-get :height org-babel-default-header-args:R) 640)
+    
+For appending string to value of an exist key in `header-args`, see [pull-6](https://github.com/fniessen/refcard-org-babel/pull/6).
 
 This can also be done file-wide (for certain files) through the use of:
 

--- a/docs/header-args.org
+++ b/docs/header-args.org
@@ -87,9 +87,11 @@ These default language-specific header arguments can be changed by the user:
 (add-to-list 'org-babel-default-header-args:R
              '(:session . "*org-R*"))
 
-(add-to-list 'org-babel-default-header-args:R
-             '((:width . 640) (:height . 640)))
+(setf (alist-get :width org-babel-default-header-args:R) 640)
+(setf (alist-get :height org-babel-default-header-args:R) 640)
 #+end_src
+
+For appending string to value of an exist key in ~header-args~, see [[https://github.com/fniessen/refcard-org-babel/pull/6][pull-6]].
 
 This can also be done file-wide (for certain files) through the use of:
 - [[id:aebeec14-5693-4c38-8040-c91d28ade608][property lines]] or


### PR DESCRIPTION
original code may return a `org-babel-default-header-args:R` with `(((:width . 640) (:height . 640)))`, but i found `((:width . 640) (:height . 640))` is the correct one to get header-args for code block work. Alternatively one can also use `add-to-list` twice.