### PR TITLE
Fix broken link to GitHub issues

### DIFF
--- a/docs/colophon.md
+++ b/docs/colophon.md
@@ -16,7 +16,7 @@ The primary sources for this documentation are:
 
 ## Issues
 
-Report issues and suggest features and improvements on the [GitHub issue tracker](https://github.com/fniessen/refcard-org-babel /issues/new).
+Report issues and suggest features and improvements on the [GitHub issue tracker](https://github.com/fniessen/refcard-org-babel/issues/new).
 
 
 ## Patches

--- a/docs/colophon.org
+++ b/docs/colophon.org
@@ -20,7 +20,7 @@ The primary sources for this documentation are:
 
 ** Issues
 
-Report issues and suggest features and improvements on the [[https://github.com/fniessen/refcard-org-babel /issues/new][GitHub issue tracker]].
+Report issues and suggest features and improvements on the [[https://github.com/fniessen/refcard-org-babel/issues/new][GitHub issue tracker]].
 
 ** Patches
 


### PR DESCRIPTION
This fixes a typo in the URL to the GitHub issues page.