### PR TITLE
Multiple variables in header using :var require space separation

### DIFF
--- a/docs/header-args.md
+++ b/docs/header-args.md
@@ -1934,10 +1934,10 @@ Controls the permissions of tangled files.
 ## Remarks
 
 Multiple `var` specifications behind a single `:var` are allowed.  The multiple
-var arguments must be comma-separated:
+var arguments must be space-separated:
 
-    #+PROPERTY: header-args :var foo=1, bar=2
     
+    #+PROPERTY: header-args :var foo=1 bar=2
     #+begin_src emacs-lisp
     (+ foo bar)
     #+end_src
@@ -1947,7 +1947,7 @@ var arguments must be comma-separated:
 
 and
 
-    #+begin_src emacs-lisp :var foo="hello", bar="world"
+    #+begin_src emacs-lisp :var foo="hello" bar="world"
     (concat foo " " bar)
     #+end_src
     

--- a/docs/header-args.org
+++ b/docs/header-args.org
@@ -2098,10 +2098,10 @@ plot(1)
 ** Remarks
 
 Multiple ~var~ specifications behind a single ~:var~ are allowed.  The multiple
-var arguments must be comma-separated:
+var arguments must be space-separated:
 
 #+begin_src org
-,#+PROPERTY: header-args :var foo=1, bar=2
+,#+PROPERTY: header-args :var foo=1 bar=2
 
 ,#+begin_src emacs-lisp
 (+ foo bar)
@@ -2114,7 +2114,7 @@ var arguments must be comma-separated:
 and
 
 #+begin_src org
-,#+begin_src emacs-lisp :var foo="hello", bar="world"
+,#+begin_src emacs-lisp :var foo="hello" bar="world"
 (concat foo " " bar)
 ,#+end_src
 


### PR DESCRIPTION
Solves #8 